### PR TITLE
[Refactor] Vaccine "version number" to "timestamp" and remote retrieval

### DIFF
--- a/sk-vaccine-app/controllers/__tests__/vaccineDataController.test.ts
+++ b/sk-vaccine-app/controllers/__tests__/vaccineDataController.test.ts
@@ -357,7 +357,7 @@ describe("VaccineDataController MockDB Tests", () => {
 
     it("should update the vaccine list successfully", async () => {
       const mockVaccineList = {
-        version: "1",
+        timestamp: 1743273741,
         vaccines: [
           {
             vaccineName: "DTaP-IPV-Hib",

--- a/sk-vaccine-app/controllers/__tests__/vaccineListService.data.json
+++ b/sk-vaccine-app/controllers/__tests__/vaccineListService.data.json
@@ -1,5 +1,5 @@
 {
-  "version": 12,
+  "timestamp": 1743273741,
   "vaccines": [
     {
       "vaccineName": "DTaP-IPV-Hib",

--- a/sk-vaccine-app/services/__tests__/vaccineListService.data.json
+++ b/sk-vaccine-app/services/__tests__/vaccineListService.data.json
@@ -1,5 +1,5 @@
 {
-  "version": 12,
+  "timestamp": 1743273741,
   "vaccines": [
     {
       "vaccineName": "DTaP-IPV-Hib",

--- a/sk-vaccine-app/services/vaccineDataService.ts
+++ b/sk-vaccine-app/services/vaccineDataService.ts
@@ -84,14 +84,14 @@ export class VaccineDataService implements iVaccineDataService {
       query += ` ORDER BY ${order.column} ${order.ascending ? "ASC" : "DESC"}`;
     }
     logger.debug(`Vaccine query ${query}`);
-    console.log(query, params)
+    console.log(query, params);
     try {
       const result: VaccineQueryResult[] = await VaccineEntity.query(
         query,
         params
       );
       logger.debug(`Vaccine query result ${result[0]}`);
-      console.log(result)
+      console.log(result);
       return result;
     } catch (error) {
       logger.error(`Error running vaccineQuery ${error}`);
@@ -124,13 +124,17 @@ export class VaccineDataService implements iVaccineDataService {
    * @returns A promise containing the version number.
    */
   async getVaccineListVersionRemote(): Promise<number> {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       try {
         // TODO: Put in an actual fetch wen there is somewhere to fetch from
-        //const response = await fetch();
-        const response = tempJson;
-        logger.debug(`Remote vaccine list version: ${response.version}`);
-        resolve(response.version);
+
+        const listTimestamp = await (
+          await fetch(
+            "https://raw.githubusercontent.com/ThompsonC-collab/immsapp-data/refs/heads/main/vaccineData.json"
+          )
+        ).json();
+        logger.debug(`Remote vaccine list version: ${listTimestamp.timestamp}`);
+        resolve(listTimestamp.timestamp);
       } catch (error) {
         logger.error("Error getting remote vaccine list version\nError", error);
         reject(error);
@@ -221,21 +225,20 @@ export class VaccineDataService implements iVaccineDataService {
    * @returns a promise containing the updated vaccine list
    */
   async getVaccineListRemote(): Promise<VaccineListResponse> {
-    const url: string = "";
+    const url: string =
+      "https://raw.githubusercontent.com/ThompsonC-collab/immsapp-data/refs/heads/main/vaccineData.json";
 
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       try {
-        // TODO: Don't have the link to request from yet
-        //const response = await fetch()
-        const response = tempJson;
-        /*
-                if (!response.ok) {
-                    throw new Error(`HTTP error, Status: ${response.status}`);
-                }
-                const data = await response.json();
-                */
-        logger.debug(`Remote list version :${response.version}`);
-        const data = response;
+        const response = await fetch(url);
+
+        if (!response.ok) {
+          throw new Error(`HTTP error, Status: ${response.status}`);
+        }
+        const data = await response.json();
+
+        logger.debug(`Remote list version :${data.timestamp}`);
+
         resolve(data as VaccineListResponse);
       } catch (error) {
         logger.error("Error in getVaccineListRemote:", error);

--- a/sk-vaccine-app/services/vaccineListService.data.json
+++ b/sk-vaccine-app/services/vaccineListService.data.json
@@ -1,5 +1,5 @@
 {
-  "version": 12,
+  "timestamp": 1743273741,
   "vaccines": [
     {
       "vaccineName": "DTaP-IPV-Hib",


### PR DESCRIPTION
## What does this PR do? 
<!-- Github issue number -->
### Brief Summary / Bullet Points
- Updated the vaccine list "version number" to now be a "timestamp" due to the auto scraping
- The data is now pulled from the remote repo rather than locally.

<!-- Please include a summary of the change and which issue is fixed. Feel free to include screenshots or links as neccesary -->


## Any new packages added? If yes list them here
- no

- [ ] `npm i` required

## What type of change is this
- [ ] Feature
- [ ] Bug Fix
- [x] Other

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have linted and formatted the code
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
<!-- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. -->

