### PR TITLE
[Refactor] Changed the layout of sub pages

### DIFF
--- a/sk-vaccine-app/app/_layout.tsx
+++ b/sk-vaccine-app/app/_layout.tsx
@@ -62,7 +62,8 @@ export default function RootLayout() {
         headerStyle: {
           backgroundColor: "transparent", // Ensures transparency
         },
-        headerRight: () => <CustomHeader />,
+        //headerBackVisible: true,
+        headerRight: () => <SettingsButton />,
         headerTitle: "", // Memoize the header, supposed to prevent updates but I am unsure about that
       }}
     />

--- a/sk-vaccine-app/app/clinic-info/_layout.tsx
+++ b/sk-vaccine-app/app/clinic-info/_layout.tsx
@@ -1,0 +1,32 @@
+import { Stack } from "expo-router";
+import { View, Text, StyleSheet } from "react-native";
+import { memo } from "react";
+import React from "react";
+import { RFPercentage } from "react-native-responsive-fontsize";
+
+
+
+export default function ClinicInfoLayout() {
+  return (
+    <Stack
+  screenOptions={{
+    headerTitle: () => <Text style={styles.headerTitle} >Clinic List</Text>,
+    headerTitleAlign: "center", // Centers the title
+    headerRight: () => null, // Fully remove inherited SettingsButton
+    headerBackVisible: true,
+  }}
+/>
+  );
+}
+
+const styles = StyleSheet.create({
+    headerContainer: {
+      alignItems: "center",
+      justifyContent: "center",
+      flex: 1,
+    },
+    headerTitle: {
+        fontSize: RFPercentage(4), // Increase the text size
+        fontFamily: "MYRIADPRO-REGULAR",
+    },
+  });

--- a/sk-vaccine-app/app/clinic-info/index.tsx
+++ b/sk-vaccine-app/app/clinic-info/index.tsx
@@ -19,7 +19,7 @@ import { RFPercentage } from "react-native-responsive-fontsize";
 
 const URL = process.env.EXPO_PUBLIC_CLINIC_LIST_URL;
 
-export default function Page() {
+export default function ClinicInfo() {
   const [searchVal, setSearchVal] = useState("");
 
   logger.debug("searchVal", searchVal);
@@ -43,9 +43,8 @@ export default function Page() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.clinicListSection}>
+      <View>
         <View style={styles.clinicListBanner}>
-          <Text style={styles.clinicListHeading}>Clinics</Text>
           <Text style={styles.clinicListSubheading}>
             Clinics offering vaccinations intended for persons under 18 years of
             age
@@ -59,29 +58,31 @@ export default function Page() {
           </View>
         </View>
 
-        {loading && !error && <ActivityIndicator size="large" />}
+        <View style={styles.clinicListSection}>
+          {loading && !error && <ActivityIndicator size="large" />}
 
-        <FlatList
-          data={filteredClinics}
-          renderItem={({ item, index }) => {
-            const bgColor = index % 2 ? COLOURS.WHITE : COLOURS.LIGHT_GREY;
-            return (
-              <View style={{ marginTop: 16 }}>
-                <ClinicCard
-                  key={index}
-                  title={item.name || ""}
-                  subtitle={item.serviceArea || ""}
-                  text={item.address || ""}
-                  bgColor={bgColor}
-                  pathname={PATH_DISPLAY_CLINIC}
-                  params={item}
-                />
-              </View>
-            );
-          }}
-          keyExtractor={(item, index) => index.toString()}
-          contentContainerStyle={styles.clinicCardsContainer}
-        />
+          <FlatList
+            data={filteredClinics}
+            renderItem={({ item, index }) => {
+              const bgColor = index % 2 ? COLOURS.WHITE : COLOURS.LIGHT_GREY;
+              return (
+                <View style={{ marginTop: 16 }}>
+                  <ClinicCard
+                    key={index}
+                    title={item.name || ""}
+                    subtitle={item.serviceArea || ""}
+                    text={item.address || ""}
+                    bgColor={bgColor}
+                    pathname={PATH_DISPLAY_CLINIC}
+                    params={item}
+                  />
+                </View>
+              );
+            }}
+            keyExtractor={(item, index) => index.toString()}
+            contentContainerStyle={styles.clinicCardsContainer}
+          />
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -93,17 +94,21 @@ const styles = StyleSheet.create({
     backgroundColor: COLOURS.WHITE,
   },
   clinicListSection: {
-    flex: 1,
     marginHorizontal: 3,
     paddingHorizontal: 16,
     fontFamily: "Arial",
     color: COLOURS.BLACK,
   },
   clinicListBanner: {
-    backgroundColor: COLOURS.WHITE,
     padding: 16,
     borderRadius: 4,
-    marginTop: 16,
+    backgroundColor: COLOURS.WHITE,
+    borderBottomWidth: 0, // Border thickness
+    shadowColor: "#000", // Shadow color for iOS
+    shadowOffset: { width: 0, height: 2 }, // Shadow offset for iOS
+    shadowOpacity: 0.2, // Shadow opacity for iOS
+    shadowRadius: 4, // Shadow radius for iOS
+    elevation: 5, // Shadow for Android
   },
   clinicListHeading: {
     margin: 0,
@@ -121,7 +126,7 @@ const styles = StyleSheet.create({
   searchBarWrapper: {
     backgroundColor: COLOURS.SEARCHBAR_BG,
     borderRadius: 24,
-    marginVertical: 16,
+    marginTop: 16,
     paddingVertical: 8,
     paddingHorizontal: 12,
   },

--- a/sk-vaccine-app/app/display-clinic/_layout.tsx
+++ b/sk-vaccine-app/app/display-clinic/_layout.tsx
@@ -1,0 +1,40 @@
+import { Stack, useLocalSearchParams } from "expo-router";
+import { View, Text, StyleSheet } from "react-native";
+import { memo } from "react";
+import React from "react";
+import { RFPercentage } from "react-native-responsive-fontsize";
+import assert from "assert";
+import { Clinic } from "@/services/clinicDataService";
+
+export default function DisplayClinicLayout() {
+  const { data } = useLocalSearchParams<{ data: string }>();
+  assert(data, "No data given to DisplayClinic page in routing parameters");
+  const parsedData = JSON.parse(data);
+
+  const clinic: Clinic = parsedData || {};
+  const clinicName = clinic.name || "Clinic Name Not Provided";
+  return (
+    <Stack
+      screenOptions={{
+        headerTitle: () => <Text style={styles.headerTitle}>{clinicName}</Text>,
+        headerTitleAlign: "center", // Centers the title
+        headerRight: () => null, // Fully remove inherited SettingsButton
+        headerBackVisible: true,
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  headerContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+  },
+  headerTitle: {
+    fontSize: RFPercentage(3.5), // Increase the text size
+    marginRight: 10,
+    fontFamily: "MYRIADPRO-REGULAR",
+    textAlign: "center",
+  },
+});

--- a/sk-vaccine-app/app/display-clinic/index.tsx
+++ b/sk-vaccine-app/app/display-clinic/index.tsx
@@ -39,7 +39,6 @@ export default function DisplayClinic() {
         <>
             <ScrollView style={styles.container}>
                 <View style={styles.headerCard}>
-                    <Text style={styles.headerTitle} selectable>{clinicName}</Text>
                     <Text style={styles.headerSubtitle} selectable>{clinicServiceArea}</Text>
                 </View>
 

--- a/sk-vaccine-app/app/display-vaccine/_layout.tsx
+++ b/sk-vaccine-app/app/display-vaccine/_layout.tsx
@@ -1,0 +1,39 @@
+import { Stack, useLocalSearchParams } from "expo-router";
+import { View, Text, StyleSheet } from "react-native";
+import { memo } from "react";
+import React from "react";
+import { RFPercentage } from "react-native-responsive-fontsize";
+import assert from "assert";
+import { VaccineSheet } from "@/interfaces/iVaccineData";
+
+export default function DisplayVaccineLayout() {
+  const { data } = useLocalSearchParams<{ data: string }>();
+  assert(data, "No data given to DisplayVaccine page in routing parameters");
+  const parsedData = JSON.parse(data);
+  const pageData: VaccineSheet = parsedData;
+  return (
+    <Stack
+      screenOptions={{
+        headerTitle: () => <Text style={styles.headerTitle}>{pageData.vaccineName}</Text>,
+        headerTitleAlign: "center", // Centers the title
+        headerRight: () => null, // Fully remove inherited SettingsButton
+        headerBackVisible: true,
+       
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  headerContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+  },
+  headerTitle: {
+    fontSize: RFPercentage(3.5), // Increase the text size
+    marginRight: 10,
+    fontFamily: "MYRIADPRO-REGULAR",
+    textAlign: "center",
+  },
+});

--- a/sk-vaccine-app/app/display-vaccine/index.tsx
+++ b/sk-vaccine-app/app/display-vaccine/index.tsx
@@ -28,7 +28,6 @@ export default function DisplayVaccine() {
     <>
       <View style={{ flex: 1, backgroundColor: "#0B6A41" }}>
         <View style={styles.headerCard}>
-          <Text style={styles.headerTitle}>{pageData.vaccineName}</Text>
           <Text style={styles.headerSubtitle}>
             Starting Age/Grade: {pageData.starting}
           </Text>

--- a/sk-vaccine-app/app/vaccine-info/_layout.tsx
+++ b/sk-vaccine-app/app/vaccine-info/_layout.tsx
@@ -1,0 +1,32 @@
+import { Stack } from "expo-router";
+import { View, Text, StyleSheet } from "react-native";
+import { memo } from "react";
+import React from "react";
+import { RFPercentage } from "react-native-responsive-fontsize";
+
+
+
+export default function VaccineInfoLayout() {
+  return (
+    <Stack
+  screenOptions={{
+    headerTitle: () => <Text style={styles.headerTitle} >Vaccine List</Text>,
+    headerTitleAlign: "center", // Centers the title
+    headerRight: () => null, // Fully remove inherited SettingsButton
+    headerBackVisible: true,
+  }}
+/>
+  );
+}
+
+const styles = StyleSheet.create({
+    headerContainer: {
+      alignItems: "center",
+      justifyContent: "center",
+      flex: 1,
+    },
+    headerTitle: {
+        fontSize: RFPercentage(4), // Increase the text size
+        fontFamily: "MYRIADPRO-REGULAR",
+    },
+  });

--- a/sk-vaccine-app/app/vaccine-info/index.tsx
+++ b/sk-vaccine-app/app/vaccine-info/index.tsx
@@ -1,6 +1,6 @@
 import SearchBar from "@/components/search-bar";
 import ClinicCard from "@/components/card-link";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   SafeAreaView,
   View,
@@ -16,9 +16,9 @@ import logger from "@/utils/logger";
 import { VaccineDataService } from "@/services/vaccineDataService";
 import { COLOURS } from "@/utils/colours";
 import { RFPercentage } from "react-native-responsive-fontsize";
+import { useNavigation } from "expo-router";
 
-
-export default function Page() {
+export default function VaccineInfo() {
   const [searchVal, setSearchVal] = useState("");
 
   logger.debug("searchVal", searchVal);
@@ -28,11 +28,18 @@ export default function Page() {
     vaccineController: new VaccineDataController(new VaccineDataService()),
   });
 
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: () => null, // Force-remove SettingsButton at runtime
+    });
+  }, [navigation]);
+
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.clinicListSection}>
+      <View>
         <View style={styles.clinicListBanner}>
-          <Text style={styles.clinicListHeading}>Vaccine List</Text>
           <Text style={styles.clinicListSubheading}>
             Vaccinations intended for persons under 18 years of age
           </Text>
@@ -46,31 +53,32 @@ export default function Page() {
             />
           </View>
         </View>
+        <View style={styles.clinicListSection}>
+          {loading && !error && <ActivityIndicator size="large" />}
 
-        {loading && !error && <ActivityIndicator size="large" />}
-
-        <FlatList
-          data={vaccineSheets}
-          renderItem={({ item, index }) => {
-            const bgColor = index % 2 ? COLOURS.WHITE : COLOURS.LIGHT_GREY;
-            logger.debug(`Pdf path ${item.pdfPath}`);
-            return (
-              <View style={{ marginTop: 16 }}>
-                <ClinicCard
-                  key={index}
-                  title={item.vaccineName}
-                  subtitle={item.starting}
-                  bgColor={bgColor}
-                  pathname={PATH_DISPLAY_VACCINE}
-                  params={item}
-                  text={""}
-                />
-              </View>
-            );
-          }}
-          keyExtractor={(item, index) => index.toString()}
-          contentContainerStyle={styles.clinicCardsContainer}
-        />
+          <FlatList
+            data={vaccineSheets}
+            renderItem={({ item, index }) => {
+              const bgColor = index % 2 ? COLOURS.WHITE : COLOURS.LIGHT_GREY;
+              logger.debug(`Pdf path ${item.pdfPath}`);
+              return (
+                <View style={{ marginTop: 16 }}>
+                  <ClinicCard
+                    key={index}
+                    title={item.vaccineName}
+                    subtitle={item.starting}
+                    bgColor={bgColor}
+                    pathname={PATH_DISPLAY_VACCINE}
+                    params={item}
+                    text={""}
+                  />
+                </View>
+              );
+            }}
+            keyExtractor={(item, index) => index.toString()}
+            contentContainerStyle={styles.clinicCardsContainer}
+          />
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -82,17 +90,22 @@ const styles = StyleSheet.create({
     backgroundColor: COLOURS.WHITE,
   },
   clinicListSection: {
-    flex: 1,
     marginHorizontal: 3,
     paddingHorizontal: 16,
     fontFamily: "Arial",
     color: COLOURS.BLACK,
   },
   clinicListBanner: {
-    backgroundColor: COLOURS.WHITE,
     padding: 16,
     borderRadius: 4,
-    marginTop: 16,
+    backgroundColor: COLOURS.WHITE,
+    paddingBottom: 15,
+    borderBottomWidth: 0, // Border thickness
+    shadowColor: "#000", // Shadow color for iOS
+    shadowOffset: { width: 0, height: 2 }, // Shadow offset for iOS
+    shadowOpacity: 0.2, // Shadow opacity for iOS
+    shadowRadius: 4, // Shadow radius for iOS
+    elevation: 5, // Shadow for Android
   },
   clinicListHeading: {
     margin: 0,
@@ -110,7 +123,7 @@ const styles = StyleSheet.create({
   searchBarWrapper: {
     backgroundColor: COLOURS.SEARCHBAR_BG,
     borderRadius: 24,
-    marginVertical: 16,
+    marginTop: 16,
     paddingVertical: 8,
     paddingHorizontal: 12,
   },


### PR DESCRIPTION
## What does this PR do?
<!-- Github issue number -->
Alters the layout of all sub-pages. Each sub-page now has a header for the it's title. The titles therefore look much better and fit nicer. 

Also updated the look of the vaccine and clinic list pages to enhance visibility.

### Brief Summary / Bullet Points

<!-- Please include a summary of the change and which issue is fixed. Feel free to include screenshots or links as neccesary -->
- Sub pages now have custom headers with their titles
- Dynamic clinic and vaccine pages have dynamic titles
- Vaccine and clinic list looks nicer with shadowing

| Before | After |
|----------|--------|
| ![image](https://github.com/user-attachments/assets/df613fae-b069-4813-9bd6-00d48b53b1a3) | ![image](https://github.com/user-attachments/assets/189b48ad-6e31-4c08-8e61-93245fc9c1dc) | 
| ![image](https://github.com/user-attachments/assets/1dee0b69-9478-4d35-aec9-1140f7e16d98) | ![image](https://github.com/user-attachments/assets/e63c5cb3-4eef-4f1e-aaf6-31c1e733beed) |
| ![image](https://github.com/user-attachments/assets/2cf5e539-dfe7-40b8-aad3-228884be9e25) | ![image](https://github.com/user-attachments/assets/105ee3de-fe92-4abb-925a-0ead30df1676) |
| ![image](https://github.com/user-attachments/assets/0d5b3a32-83f1-4b1a-b23b-f2098358cfb2) | ![image](https://github.com/user-attachments/assets/fbb27278-dac9-46e6-a294-4061756868bc) |

## Any new packages added? If yes list them here
- no

- [ ] `npm i` required

## What type of change is this
- [x] Feature
- [ ] Bug Fix
- [ ] Other

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have linted and formatted the code
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
<!-- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox. -->

